### PR TITLE
feat: add a few icons I wanted to use

### DIFF
--- a/packages/icons/src/icon-mapping.ts
+++ b/packages/icons/src/icon-mapping.ts
@@ -1,4 +1,12 @@
 export const ICON_MAPPING = {
+  'format-font': {
+    sfSymbol: 'textformat',
+    type: 'MaterialCommunityIcons'
+  },
+  'format-size': {
+    sfSymbol: 'textformat.size',
+    type: 'MaterialIcons',
+  },
   'tray-arrow-up': {
     sfSymbol: 'square.and.arrow.up',
     type: 'MaterialCommunityIcons',


### PR DESCRIPTION
`format-font`
iOS:
<img width="66" alt="Screenshot 2024-10-17 at 11 26 38 AM" src="https://github.com/user-attachments/assets/2c915f18-a3f5-480f-aa09-bca0633d713b">
Android:
<img width="65" alt="Screenshot 2024-10-17 at 4 21 33 PM" src="https://github.com/user-attachments/assets/6b397b3f-3b81-4507-9d3a-e7e2b0584055">

`format-size`
iOS:
<img width="39" alt="Screenshot 2024-10-17 at 4 23 53 PM" src="https://github.com/user-attachments/assets/62511320-5be5-468b-987a-42a70e968ef1">
Android:
<img width="48" alt="Screenshot 2024-10-17 at 4 23 42 PM" src="https://github.com/user-attachments/assets/918a8031-5355-46e1-9f6c-e182fe45335c">

