### PR TITLE
Add icons: run, share-variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ _To select the `name` from its `SF Symbol Name`, add the prop of `namingScheme="
 | rewind-outline                  | MaterialCommunityIcons | backward                                     |
 | router                          | MaterialIcons          | wifi.router.fill                             |
 | ruler                           | MaterialCommunityIcons | ruler.fill                                   |
+| run                             | MaterialCommunityIcons | figure.run                                   |
 | scanner                         | MaterialCommunityIcons | scanner                                      |
 | screwdriver                     | MaterialCommunityIcons | screwdriver                                  |
 | script                          | MaterialCommunityIcons | scroll.fill                                  |
@@ -606,6 +607,7 @@ _To select the `name` from its `SF Symbol Name`, add the prop of `namingScheme="
 | send-circle-outline             | MaterialCommunityIcons | paperplane.circle                            |
 | send-outline                    | MaterialCommunityIcons | paperplane                                   |
 | server                          | MaterialCommunityIcons | server.rack                                  |
+| share-variant                   | MaterialCommunityIcons | square.and.arrow.up.fill                     |
 | shield                          | MaterialCommunityIcons | shield.fill                                  |
 | shield-check                    | MaterialCommunityIcons | checkmark.shield.fill                        |
 | shield-check-outline            | MaterialCommunityIcons | checkmark.shield                             |

--- a/packages/icons/src/__generated/sf-symbol-mapping.ts
+++ b/packages/icons/src/__generated/sf-symbol-mapping.ts
@@ -1,4 +1,12 @@
 export const SF_SYMBOL_MAPPING = {
+  "figure.run": {
+    "type": "MaterialCommunityIcons",
+    "material": "run"
+  },
+  "square.and.arrow.up.fill": {
+    "type": "MaterialCommunityIcons",
+    "material": "share-variant"
+  },
   "square.and.arrow.up": {
     "type": "MaterialCommunityIcons",
     "material": "tray-arrow-up"

--- a/packages/icons/src/icon-mapping.ts
+++ b/packages/icons/src/icon-mapping.ts
@@ -1,4 +1,12 @@
 export const ICON_MAPPING = {
+  'run': {
+    sfSymbol: 'figure.run',
+    type: 'MaterialCommunityIcons'
+  },
+  'share-variant':{ 
+    sfSymbol: 'square.and.arrow.up.fill',
+    type: 'MaterialCommunityIcons'
+  },
   'format-font': {
     sfSymbol: 'textformat',
     type: 'MaterialCommunityIcons'


### PR DESCRIPTION
Add mapping for two icons: `run` and `share-variant`

```jsx
<Icon name={'run'} />
```
Android:
![image](https://github.com/user-attachments/assets/28a2134f-8ecd-43d6-8078-d1874a71881c)
iOS
![image](https://github.com/user-attachments/assets/2a3562a8-235e-4451-bc7d-a8d1a38b26c6)


```jsx
<Icon name={'share-variant'} />
```
Android:
![image](https://github.com/user-attachments/assets/994985f7-00ed-4e27-9673-ad67a7f8c475)
iOS:
![image](https://github.com/user-attachments/assets/68b7e1f0-bb7c-4f04-bbed-cb6d0fa460f1)


